### PR TITLE
Use filtered table output to list running Otel containers

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -23,13 +23,10 @@ func getIDs(dockerOutput []byte) []string {
 	var result []string
 	outputArray := strings.Split(string(dockerOutput), "\n")
 
-	for _, entry := range outputArray {
-		// Each container in the Docker Compose stack will have the name of the directory
-		if strings.Contains(entry, otelConfigDirName) {
-			fields := strings.Fields(entry)
-			if len(fields) > 0 {
-				result = append(result, fields[0])
-			}
+	for _, entry := range outputArray[1:] {
+		fields := strings.Fields(entry)
+		if len(fields) > 0 {
+			result = append(result, fields[0])
 		}
 	}
 
@@ -42,8 +39,7 @@ func cleanUp() error {
 	}
 
 	fmt.Println("Stopping Spin OTel Docker containers...")
-
-	getContainers := exec.Command("docker", "ps")
+	getContainers := exec.Command("docker", "ps", fmt.Sprintf("--filter=name=%s*", otelConfigDirName), "--format=table")
 	dockerPsOutput, err := getContainers.CombinedOutput()
 	if err != nil {
 		fmt.Println(string(dockerPsOutput))

--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -23,6 +23,8 @@ func getIDs(dockerOutput []byte) []string {
 	var result []string
 	outputArray := strings.Split(string(dockerOutput), "\n")
 
+	// skip the first line of the output, because it is the table header row
+	// docker ps does not support hiding column headers
 	for _, entry := range outputArray[1:] {
 		fields := strings.Fields(entry)
 		if len(fields) > 0 {


### PR DESCRIPTION
With this PR, the implementation of `spin otel cleanup` is changed to explicitly set `table` output. By explicitly using the `table` output, the corresponding output will always contain the name of running containers. 

Additionally, a filter condition is added to retrieve only those containers that were spawned by `spin otel setup`.

Fixes #16
