### PR TITLE
Add remove flag to cleanup command

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -61,7 +61,7 @@ func cleanUp() error {
 
 	// The `docker stop` command will throw an error if there are no containers to stop
 	if len(containerIDs) == 0 {
-		fmt.Println("No Spin OTel resources found. Nothing to clean up.")
+		fmt.Println("No Spin OpenTelemetry resources found. Nothing to clean up.")
 		return nil
 	}
 


### PR DESCRIPTION
This PR adds the `remove` flag to the `cleanup` command. By specifying the remove flag (shorthand r) users can alter the behavior of the cleanup command to actually remove the OTel containers, instead of just stopping them.

Fixes #18 