### PR TITLE
Add .NET Aspire Dashboard as alternative observability stack

### DIFF
--- a/cmd/open/aspire.go
+++ b/cmd/open/aspire.go
@@ -1,0 +1,18 @@
+package open
+
+import (
+	"github.com/pkg/browser"
+	"github.com/spf13/cobra"
+)
+
+var AspireCmd = &cobra.Command{
+	Use:   "aspire",
+	Short: "Opens the .NET Aspire Dashboard in the default browser.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return aspire()
+	},
+}
+
+func aspire() error {
+	return browser.OpenURL("http://localhost:18888")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,4 +69,5 @@ func init() {
 	openCmd.AddCommand(open.GrafanaCmd)
 	openCmd.AddCommand(open.JaegerCmd)
 	openCmd.AddCommand(open.PrometheusCmd)
+	openCmd.AddCommand(open.AspireCmd)
 }

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -32,13 +32,13 @@ func setUp(s Stack) error {
 	if err := checkDocker(); err != nil {
 		return err
 	}
-	fn := s.GetComposeFileName()
-	composeFile := path.Join(otelConfigPath, fn)
-	if _, err := os.Stat(composeFile); os.IsNotExist(err) {
-		return fmt.Errorf("The \"otel-config\" directory is missing the \"%s\" file, so please consider removing and re-installing the otel plugin", fn)
+	composeFileName := s.GetComposeFileName()
+	composeFilePath := path.Join(otelConfigPath, composeFileName)
+	if _, err := os.Stat(composeFilePath); os.IsNotExist(err) {
+		return fmt.Errorf("The \"otel-config\" directory is missing the \"%s\" file, so please consider removing and re-installing the otel plugin", composeFileName)
 	}
 
-	cmd := exec.Command("docker", "compose", "-f", composeFile, "up", "-d")
+	cmd := exec.Command("docker", "compose", "-f", composeFilePath, "up", "-d")
 
 	fmt.Println("Pulling and running Spin OTel resources...")
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path"
 
+	"github.com/fermyon/otel-plugin/internal/stack"
 	"github.com/spf13/cobra"
 )
 
@@ -15,7 +16,7 @@ var (
 		Use:   "setup",
 		Short: "Run OTel dependencies in Docker.",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			s := GetStackByFlags(aspire)
+			s := stack.GetStackByFlags(aspire)
 			if err := setUp(s); err != nil {
 				return err
 			}
@@ -28,7 +29,7 @@ func init() {
 	setUpCmd.PersistentFlags().BoolVarP(&aspire, "aspire", "", false, "Use .NET Aspire dashboard as OTel stack")
 }
 
-func setUp(s Stack) error {
+func setUp(s stack.Stack) error {
 	if err := checkDocker(); err != nil {
 		return err
 	}

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -1,0 +1,30 @@
+package cmd
+
+// To add support for an additional observability stack, do the following:
+// 1. Add a const with the name of the stack
+// 2. Update the switch branch of GetComposeFileName()
+// 3. Add Stack specific Compose file to the `./otel-config` folder
+// 4. Add the Stack specific Compose file to the list of assets in `./spin-pluginify.toml`
+type Stack int
+
+const (
+	Aspire Stack = iota
+	Default
+)
+
+func GetStackByFlags(aspire bool) Stack {
+	if aspire {
+		return Aspire
+	}
+	return Default
+}
+
+func (s Stack) GetComposeFileName() string {
+	switch s {
+	case Aspire:
+		return "compose.aspire.yaml"
+	default:
+		return "compose.yaml"
+
+	}
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -37,6 +37,7 @@ func up(args []string) error {
 	cmd.Env = append(
 		os.Environ(),
 		"OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4318",
+		"OTEL_EXPORTER_OTLP_HEADERS=x-otlp-api-key=SpinOTelApiKey",
 	)
 
 	cmd.Stdout = os.Stdout

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -1,4 +1,4 @@
-package cmd
+package stack
 
 // To add support for an additional observability stack, do the following:
 // 1. Add a const with the name of the stack

--- a/otel-config/compose.aspire.yaml
+++ b/otel-config/compose.aspire.yaml
@@ -1,0 +1,15 @@
+version: "3"
+services:
+  aspire-dashboard:
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.1.0
+    restart: always
+    environment:
+      - ASPIRE_ALLOW_UNSECURED_TRANSPORT=true
+      - DASHBOARD__FRONTEND__AUTHMODE=Unsecured
+      - DASHBOARD__OTLP__AUTHMODE=ApiKey
+      - DASHBOARD__OTLP__PRIMARYAPIKEY=SpinOTelApiKey
+      - DASHBOARD__OTLP__CORS=http://localhost:3000
+    ports:
+      - "18888:18888" # .NET Aspire Dashboard UI endpoint
+      - "4317:18889" # OTLP gRPC endpoint
+      - "4318:18890" # OTLP HTTP endpoint

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -4,10 +4,11 @@ spin_compatibility = ">=2.5"
 license = "Apache-2.0"
 package = "otel"
 assets = [
+    "otel-config/compose.aspire.yaml",
     "otel-config/compose.yaml",
     "otel-config/grafana.yaml",
     "otel-config/loki.yaml",
     "otel-config/otel-collector-config.yaml",
     "otel-config/prometheus.yaml",
-    "otel-config/tempo.yaml"
+    "otel-config/tempo.yaml",
 ]


### PR DESCRIPTION
This PR adds .NET Aspire Dashboard (Standalone Mode) as alternative observability stack.

Users can specify the `--aspire` flag as part of `spin otel setup`:

```bash
spin otel setup --aspire
```

Additionally, a new sub-command is added to `spin otel open` to open the Aspire Dashboard UI from the terminal:

```bash
spin otel open aspire
```


Fixes #19 