### PR TITLE
Bump `otel` to v0.1.3

### DIFF
--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,5 +1,5 @@
 name = "otel"
-version = "0.1.2"
+version = "0.1.3"
 spin_compatibility = ">=2.5"
 license = "Apache-2.0"
 package = "otel"


### PR DESCRIPTION
This PR simply bumps the plugin version to `0.1.3`