### PR TITLE
Bump .NET Aspire Dashboard version to 9.0.0

### DIFF
--- a/otel-config/compose.aspire.yaml
+++ b/otel-config/compose.aspire.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   aspire-dashboard:
-    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.1.0
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:9.0.0
     restart: always
     environment:
       - ASPIRE_ALLOW_UNSECURED_TRANSPORT=true

--- a/spin-pluginify.toml
+++ b/spin-pluginify.toml
@@ -1,5 +1,5 @@
 name = "otel"
-version = "0.1.3"
+version = "0.1.4"
 spin_compatibility = ">=2.5"
 license = "Apache-2.0"
 package = "otel"


### PR DESCRIPTION
With this PR, the Docker image for .NET Aspire Dashboard is bumped to 9.0.0