### PR TITLE
Update OTel Stacks and bump Spin version in GH Action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,8 +10,8 @@ on:
 
 env:
   PROGRAM_NAME: otel
-  SPIN_VERSION: v2.6.0
-jobs: 
+  SPIN_VERSION: v3.2.0
+jobs:
   build:
     name: Build plugin binaries
     runs-on: ubuntu-latest
@@ -19,42 +19,67 @@ jobs:
       matrix:
         config:
           # The architectures and operating systems accepted by Golang and the Pluginify tool are different for macos + arm64
-          - { goArch: "amd64", goOs: "linux", pluginifyArch: "amd64", pluginifyOs: linux}
-          - { goArch: "arm64", goOs: "linux", pluginifyArch: "aarch64", pluginifyOs: linux}
-          - { goArch: "amd64", goOs: "windows", pluginifyArch: "amd64", pluginifyOs: windows}
-          - { goArch: "arm64", goOs: "darwin", pluginifyArch: "amd64", pluginifyOs: macos}
-          - { goArch: "amd64", goOs: "darwin", pluginifyArch: "aarch64", pluginifyOs: macos}
+          - {
+              goArch: "amd64",
+              goOs: "linux",
+              pluginifyArch: "amd64",
+              pluginifyOs: linux,
+            }
+          - {
+              goArch: "arm64",
+              goOs: "linux",
+              pluginifyArch: "aarch64",
+              pluginifyOs: linux,
+            }
+          - {
+              goArch: "amd64",
+              goOs: "windows",
+              pluginifyArch: "amd64",
+              pluginifyOs: windows,
+            }
+          - {
+              goArch: "arm64",
+              goOs: "darwin",
+              pluginifyArch: "amd64",
+              pluginifyOs: macos,
+            }
+          - {
+              goArch: "amd64",
+              goOs: "darwin",
+              pluginifyArch: "aarch64",
+              pluginifyOs: macos,
+            }
     steps:
-    - name: Checkout
-      uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
 
-    - name: Setup Go
-      uses: actions/setup-go@v5
-      with:
-        go-version: stable
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
 
-    - name: Install Spin
-      uses: rajatjindal/setup-actions/spin@main
-      with:
-        version: ${{ env.SPIN_VERSION }}
+      - name: Install Spin
+        uses: rajatjindal/setup-actions/spin@main
+        with:
+          version: ${{ env.SPIN_VERSION }}
 
-    - name: Install Pluginify
-      run: spin plugins install --url https://github.com/itowlson/spin-pluginify/releases/download/canary/pluginify.json --yes
+      - name: Install Pluginify
+        run: spin plugins install --url https://github.com/itowlson/spin-pluginify/releases/download/canary/pluginify.json --yes
 
-    - name: Build Plugin Binary
-      run: GOOS=${{ matrix.config.goOs }} GOARCH=${{ matrix.config.goArch }} go build -o ${{ env.PROGRAM_NAME }} main.go
+      - name: Build Plugin Binary
+        run: GOOS=${{ matrix.config.goOs }} GOARCH=${{ matrix.config.goArch }} go build -o ${{ env.PROGRAM_NAME }} main.go
 
-    - name: Create Arch-Specific Plugin Manifest
-      run: spin pluginify --arch ${{ matrix.config.pluginifyArch }} --os ${{ matrix.config.pluginifyOs }}
+      - name: Create Arch-Specific Plugin Manifest
+        run: spin pluginify --arch ${{ matrix.config.pluginifyArch }} --os ${{ matrix.config.pluginifyOs }}
 
-    - name: Archive Binary and Manifest
-      uses: actions/upload-artifact@v4
-      with:
-        name: ${{ env.PROGRAM_NAME}}-${{ matrix.config.pluginifyOs }}-${{ matrix.config.pluginifyArch }}
-        path: |
-          *.tar.gz
-          *.json
-          
+      - name: Archive Binary and Manifest
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.PROGRAM_NAME}}-${{ matrix.config.pluginifyOs }}-${{ matrix.config.pluginifyArch }}
+          path: |
+            *.tar.gz
+            *.json
+
   package:
     name: Package Plugin
     runs-on: ubuntu-latest

--- a/otel-config/compose.aspire.yaml
+++ b/otel-config/compose.aspire.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   aspire-dashboard:
-    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.1.0
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:9.2.0
     restart: always
     environment:
       - ASPIRE_ALLOW_UNSECURED_TRANSPORT=true

--- a/otel-config/compose.yaml
+++ b/otel-config/compose.yaml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.98.0
+    image: otel/opentelemetry-collector-contrib:0.127.0
     restart: always
     command:
       - "--config=/etc/otel-collector-config.yaml"
@@ -26,9 +26,9 @@ services:
       - "14268" # can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 
   tempo:
-    image: grafana/tempo:2.4.1
+    image: grafana/tempo:2.7.2
     command:
-      - '-config.file=/etc/tempo/config.yaml'
+      - "-config.file=/etc/tempo/config.yaml"
     volumes:
       - ./tempo.yaml:/etc/tempo/config.yaml
     ports:
@@ -39,15 +39,15 @@ services:
     image: prom/prometheus:latest
     restart: always
     command:
-      - '--config.file=/etc/prometheus/prometheus.yaml'
-      - '--web.enable-remote-write-receiver'
+      - "--config.file=/etc/prometheus/prometheus.yaml"
+      - "--web.enable-remote-write-receiver"
     volumes:
       - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:10.4.2
+    image: grafana/grafana:12.0.1
     ports:
       - 5050:3000
     volumes:
@@ -61,9 +61,9 @@ services:
       - tempo
 
   loki:
-    image: grafana/loki:2.9.8
+    image: grafana/loki:3.5.1
     command:
-      - '-config.file=/etc/loki/config.yaml'
+      - "-config.file=/etc/loki/config.yaml"
     volumes:
       - ./loki.yaml:/etc/loki/config.yaml
     ports:

--- a/otel-config/loki.yaml
+++ b/otel-config/loki.yaml
@@ -5,10 +5,6 @@ server:
 
 common:
   path_prefix: /tmp/loki
-  storage:
-    filesystem:
-      chunks_directory: /tmp/loki/chunks
-      rules_directory: /tmp/loki/rules
   replication_factor: 1
   ring:
     instance_addr: 127.0.0.1
@@ -18,12 +14,16 @@ common:
 schema_config:
   configs:
     - from: 2020-09-07
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
-      schema: v12
+      schema: v13
       index:
         prefix: loki_index_
         period: 24h
 
+storage_config:
+    filesystem:
+      directory: /tmp/loki/chunks
+      
 analytics:
   reporting_enabled: false


### PR DESCRIPTION
With this PR 

- both OTel Stacks have been updated to use latest container images
- Loki schema configuration has been updated from `v12` to `v13`
- Spin version in GitHub Action has been bumped to `3.2.0`