### PR TITLE
fix: add selinux postfix for volumes and update image versions

### DIFF
--- a/otel-config/compose.yaml
+++ b/otel-config/compose.yaml
@@ -1,12 +1,12 @@
 version: "3"
 services:
   otel-collector:
-    image: otel/opentelemetry-collector-contrib:0.140.0
+    image: docker.io/otel/opentelemetry-collector-contrib:0.151.0
     restart: always
     command:
       - "--config=/etc/otel-collector-config.yaml"
     volumes:
-      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml:z
     ports:
       - "8888:8888" # Prometheus metrics exposed by the collector
       - "8889:8889" # Prometheus exporter metrics
@@ -19,39 +19,39 @@ services:
       - loki
 
   jaeger:
-    image: jaegertracing/all-in-one:1.75.0
+    image: docker.io/jaegertracing/all-in-one:1.76.0
     restart: always
     ports:
       - "16686:16686" # UI
       - "14268" # can accept spans directly from clients in jaeger.thrift format over binary thrift protocol
 
   tempo:
-    image: grafana/tempo:2.9.0
+    image: docker.io/grafana/tempo:2.9.2
     command:
       - "-config.file=/etc/tempo/config.yaml"
     volumes:
-      - ./tempo.yaml:/etc/tempo/config.yaml
+      - ./tempo.yaml:/etc/tempo/config.yaml:z
     ports:
       - 4318
       - 7999:7999
 
   prometheus:
-    image: prom/prometheus:v3.7.3
+    image: docker.io/prom/prometheus:v3.11.3
     restart: always
     command:
       - "--config.file=/etc/prometheus/prometheus.yaml"
       - "--web.enable-remote-write-receiver"
     volumes:
-      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml
+      - ./prometheus.yaml:/etc/prometheus/prometheus.yaml:z
     ports:
       - "9090:9090"
 
   grafana:
-    image: grafana/grafana:12.1
+    image: docker.io/grafana/grafana:13.0
     ports:
       - 5050:3000
     volumes:
-      - ./grafana.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+      - ./grafana.yaml:/etc/grafana/provisioning/datasources/datasources.yaml:z
     environment:
       - GF_AUTH_ANONYMOUS_ENABLED=true
       - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
@@ -61,10 +61,10 @@ services:
       - tempo
 
   loki:
-    image: grafana/loki:3.5.8
+    image: grafana/loki:3.7
     command:
       - "-config.file=/etc/loki/config.yaml"
     volumes:
-      - ./loki.yaml:/etc/loki/config.yaml
+      - ./loki.yaml:/etc/loki/config.yaml:z
     ports:
       - 3100:3100


### PR DESCRIPTION
The `:z` colon is needed for Linux distros that use SELinux (e.g. Fedora). If it's not there, users get an error stating that they don't have permission to access the mounted volumes.

Also, updating versions and making the image urls fully-qualified