### PR TITLE
cleanup: tear down otel stacks with 'compose down'

### DIFF
--- a/cmd/cleanup.go
+++ b/cmd/cleanup.go
@@ -2,17 +2,20 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
-	"strings"
+	"path"
 
 	"github.com/spf13/cobra"
+	"github.com/spinframework/otel-plugin/internal/stack"
 )
 
 var (
-	removeContainers = false
-	cleanUpCmd       = &cobra.Command{
+	removeVolumes = false
+	cleanUpCmd    = &cobra.Command{
 		Use:   "cleanup",
 		Short: "Clean up OpenTelemetry dependencies",
+		Long:  "Tears down the OpenTelemetry dependency containers started by \"spin otel setup\" (the inverse of setup). Works regardless of which stack was set up.",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := cleanUp(); err != nil {
 				return err
@@ -23,23 +26,7 @@ var (
 )
 
 func init() {
-	cleanUpCmd.Flags().BoolVarP(&removeContainers, "remove", "r", false, "If specified, OTel containers will be removed")
-}
-
-func getIDs(runtimeOutput []byte) []string {
-	var result []string
-	outputArray := strings.Split(string(runtimeOutput), "\n")
-
-	// skip the first line of the output, because it is the table header row
-	// {{runtime}} ps does not support hiding column headers
-	for _, entry := range outputArray[1:] {
-		fields := strings.Fields(entry)
-		if len(fields) > 0 {
-			result = append(result, fields[0])
-		}
-	}
-
-	return result
+	cleanUpCmd.Flags().BoolVarP(&removeVolumes, "remove-volumes", "v", false, "Also remove named volumes declared in the compose files")
 }
 
 func cleanUp() error {
@@ -48,31 +35,27 @@ func cleanUp() error {
 		return err
 	}
 
-	fmt.Println("Stopping Spin OpenTelemetry containers...")
-	getContainers := exec.Command(runtime, "ps", fmt.Sprintf("--filter=name=%s*", otelConfigDirName))
-	processOutput, err := getContainers.CombinedOutput()
-	if err != nil {
-		fmt.Println(string(processOutput))
-		return err
-	}
+	fmt.Println("Stopping and removing Spin OpenTelemetry containers...")
 
-	containerIDs := getIDs(processOutput)
+	for _, s := range stack.AllStacks() {
+		composeFileName := s.GetComposeFileName()
+		composeFilePath := path.Join(otelConfigPath, composeFileName)
+		if _, err := os.Stat(composeFilePath); os.IsNotExist(err) {
+			// A stack's compose file may not be present; nothing to tear down.
+			continue
+		}
 
-	// The `{{runtime}} stop` command will throw an error if there are no containers to stop
-	if len(containerIDs) == 0 {
-		fmt.Println("No Spin OpenTelemetry resources found. Nothing to clean up.")
-		return nil
-	}
+		downArgs := []string{"compose", "-f", composeFilePath, "down", "--remove-orphans"}
+		if removeVolumes {
+			downArgs = append(downArgs, "--volumes")
+		}
 
-	cleanupArgs := []string{"stop"}
-	if removeContainers {
-		cleanupArgs = []string{"rm", "-f"}
-	}
-	stopContainers := exec.Command(runtime, append(cleanupArgs, containerIDs...)...)
-	stopContainersOutput, err := stopContainers.CombinedOutput()
-	if err != nil {
-		fmt.Println(string(stopContainersOutput))
-		return err
+		cmd := exec.Command(runtime, downArgs...)
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			fmt.Println(string(output))
+			return err
+		}
 	}
 
 	fmt.Println("All Spin OpenTelemetry resources have been cleaned up.")

--- a/internal/stack/stack.go
+++ b/internal/stack/stack.go
@@ -12,6 +12,12 @@ const (
 	Default
 )
 
+// AllStacks returns every supported stack, so callers can operate on all of
+// them (e.g. cleanup) without needing to know which one was set up.
+func AllStacks() []Stack {
+	return []Stack{Aspire, Default}
+}
+
 func GetStackByFlags(aspire bool) Stack {
 	if aspire {
 		return Aspire


### PR DESCRIPTION
Previously 'spin otel cleanup' only ran 'docker stop' by default, leaving exited containers behind. Because the compose services use 'restart: always', the Docker daemon resurrected those containers on every boot. You could pass the removeContainers flag but that was not default behaviour.

Make cleanup the inverse of setup: run 'compose down --remove-orphans' for every stack's compose file, which removes the containers (and network) so the restart policy has nothing to bring back. Works with no flags regardless of which stack was set up; adds --remove-volumes to also drop named volumes.

This both improves the default behaviour and makes it more comprehensive.